### PR TITLE
Allow to use a custom filePattern to retrieve the block name from file path

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.0.0-beta.32",
+  "lerna": "2.0.0-beta.34",
   "packages": [
     "packages/*"
   ],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "scss-parser": "^1.0.0"
   },
   "devDependencies": {
-    "lerna": "2.0.0-beta.32"
+    "lerna": "2.0.0-beta.34"
   },
   "scripts": {
     "test": "lerna run test"

--- a/packages/bemlinter/README.md
+++ b/packages/bemlinter/README.md
@@ -109,6 +109,20 @@ default: `['']`
 }
 ```
 
+### filePattern (option)
+
+Regexp used to retrieve the block name from the file name
+
+:warning: Your regexp should contain only one capturing group
+
+default: `'([^.]*)\.scss'`
+
+```json
+{
+  "filePattern": "(?:project-)?([^.]*)\.scss"
+}
+```
+
 
 How to Contribute
 --------

--- a/packages/bemlinter/README.md
+++ b/packages/bemlinter/README.md
@@ -97,15 +97,15 @@ default: `true`
 }
 ```
 
-### prefix (option)
+### classPrefix (option)
  
-To set the authorized prefix
+To set the authorized class prefix
 
 default: `['']`
 
 ```json
 {
-  "prefix": ["c-"]
+  "classPrefix": ["c-"]
 }
 ```
 

--- a/packages/bemlinter/__tests__/__snapshots__/single-file.test.js.snap
+++ b/packages/bemlinter/__tests__/__snapshots__/single-file.test.js.snap
@@ -1,11 +1,6 @@
+exports[`Bemlinter of ProjectAlright.scss should lint without error 1`] = `"OK: bemlinter has validated 1 block."`;
+
 exports[`Bemlinter of alright.scss should lint without error 1`] = `"OK: bemlinter has validated 1 block."`;
-
-exports[`Bemlinter of alright.scss should warn the use of an external block 1`] = `
-"  ✓ warning
-[warning.scss:21] Warning: \".external-block\" is only tolerated in this stylesheet.
-
-OK: bemlinter has validated 1 block."
-`;
 
 exports[`Bemlinter of leak.scss should lint with a leak error 1`] = `
 "  ✗ leak
@@ -44,4 +39,11 @@ exports[`Bemlinter of syntax.scss should lint without a lower case error 1`] = `
 [syntax.scss:53] Error: \".syntax___footer\" element should have only 2 underscores.
 
 FAIL: bemlinter has detected 5 errors on 1 block."
+`;
+
+exports[`Bemlinter of warning.scss should warn the use of an external block 1`] = `
+"  ✓ warning
+[warning.scss:21] Warning: \".external-block\" is only tolerated in this stylesheet.
+
+OK: bemlinter has validated 1 block."
 `;

--- a/packages/bemlinter/__tests__/multiple-files.js
+++ b/packages/bemlinter/__tests__/multiple-files.js
@@ -15,10 +15,10 @@ const snap = (fileName, done, options = {}) => {
 };
 
 describe('Bemlinter of multiple files', () => {
-  it('should lint with crossed error', done => snap('cross-styling/*.scss', done, {prefix: ['c-']}));
+  it('should lint with crossed error', done => snap('cross-styling/*.scss', done, {classPrefix: ['c-']}));
   
   it('should lint without the crossed error on the excluded block', done => snap('cross-styling/*.scss', done, {
     excludeBlock: ['other-block'],
-    prefix: ['c-']
+    classPrefix: ['c-']
   }));
 });

--- a/packages/bemlinter/__tests__/single-file.test.js
+++ b/packages/bemlinter/__tests__/single-file.test.js
@@ -23,9 +23,9 @@ describe('Bemlinter of alright.scss', () => {
 });
 
 describe('Bemlinter of prefix.scss', () => {
-  it('should lint with a missing prefix error', done => snap(`prefix.scss`, done, {prefix: ['c-']}));
+  it('should lint with a missing prefix error', done => snap(`prefix.scss`, done, {classPrefix: ['c-']}));
   
-  it('should lint without error', done => snap(`prefix.scss`, done, {prefix: ['', 'c-']}));
+  it('should lint without error', done => snap(`prefix.scss`, done, {classPrefix: ['', 'c-']}));
 });
 
 describe('Bemlinter of leak.scss', () => {

--- a/packages/bemlinter/__tests__/single-file.test.js
+++ b/packages/bemlinter/__tests__/single-file.test.js
@@ -18,7 +18,13 @@ describe('Bemlinter of alright.scss', () => {
   it('should lint without error', done => snap(`alright.scss`, done));
 });
 
-describe('Bemlinter of alright.scss', () => {
+describe('Bemlinter of ProjectAlright.scss', () => {
+  it('should lint without error', done => snap(`ProjectAlright.scss`, done, {
+    filePattern: '(?:Project)?([^.]*)\.scss'
+  }));
+});
+
+describe('Bemlinter of warning.scss', () => {
   it('should warn the use of an external block', done => snap(`warning.scss`, done));
 });
 

--- a/packages/bemlinter/__tests__/sources/ProjectAlright.scss
+++ b/packages/bemlinter/__tests__/sources/ProjectAlright.scss
@@ -1,0 +1,32 @@
+.alright {
+  display: block;
+  position: absolute;
+  z-index: 10;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 29px;
+  height: 29px;
+
+  &::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: hotpink;
+  }
+}
+
+.alright--big {
+  width: 64px;
+  height: 64px;
+}
+
+.alright__close {
+  position: absolute;
+  top: 14px;
+  right: 15px;
+  
+  background-image: url('/assets/close.svg');
+}

--- a/packages/bemlinter/src/bem.js
+++ b/packages/bemlinter/src/bem.js
@@ -2,11 +2,18 @@ const _ = require('lodash');
 const path = require('path');
 const paramCase = require('param-case');
 
-module.exports = function (classPrefixList) {
+module.exports = function (classPrefixList, blockRegExp) {
   
   function getBlockNameFromFile(filePath) {
     const fileName = path.basename(filePath);
-    return paramCase(fileName.slice(0, fileName.length - 4));
+    const match = blockRegExp.exec(fileName);
+    if (!match) {
+      console.error(`No block name found for this ${fileName}. Is your filePattern option correct?`);
+    } else if (match.length > 2) {
+      console.error('Only one capturing group is authorized in filePattern!');
+    }
+
+    return paramCase(match[1]);
   }
 
   function getBlockNameFromClass(className) {

--- a/packages/bemlinter/src/bem.js
+++ b/packages/bemlinter/src/bem.js
@@ -11,16 +11,16 @@ module.exports = function (classPrefixList) {
 
   function getBlockNameFromClass(className) {
     const blockName = className.split('__')[0].split('--')[0];
-    const prefix = _.find(classPrefixList, prefix => _.startsWith(className, prefix));
-    if (!prefix) {
+    const currentClassPrefix = _.find(classPrefixList, classPrefix => _.startsWith(className, classPrefix));
+    if (!currentClassPrefix) {
       return blockName;
     }
-    return blockName.slice(prefix.length);
+    return blockName.slice(currentClassPrefix.length);
   }
 
   function isBlockName(className, blockName, withPrefixList = classPrefixList) {
-    return _.some(withPrefixList, prefix => {
-      const prefixedBlockName = `${prefix}${blockName}`;
+    return _.some(withPrefixList, classPrefix => {
+      const prefixedBlockName = `${classPrefix}${blockName}`;
       return (
         className === prefixedBlockName ||
         _.startsWith(className, `${prefixedBlockName}--`) ||

--- a/packages/bemlinter/src/lint.js
+++ b/packages/bemlinter/src/lint.js
@@ -29,7 +29,8 @@ function isClassFollowedByAPseudoClass($wrapper) {
 const defaultOptions = {
   excludeBlock: [],
   checkLowerCase: true,
-  classPrefix: ['']
+  classPrefix: [''],
+  filePattern: '([^.]*)\.scss'
 };
 
 // Exports
@@ -37,7 +38,7 @@ module.exports = (sources, userOptions = defaultOptions) => {
   const result = createResult();
   const options = _.merge({}, defaultOptions, userOptions);
   const classPrefixList = _.reverse(_.sortBy(options.classPrefix));
-  const bem = createBem(classPrefixList);
+  const bem = createBem(classPrefixList, new RegExp(options.filePattern));
   const filePathList = globby.sync(sources);
   const blockList = _.filter(
     filePathList.map(bem.getBlockNameFromFile),

--- a/packages/bemlinter/src/lint.js
+++ b/packages/bemlinter/src/lint.js
@@ -29,14 +29,14 @@ function isClassFollowedByAPseudoClass($wrapper) {
 const defaultOptions = {
   excludeBlock: [],
   checkLowerCase: true,
-  prefix: ['']
+  classPrefix: ['']
 };
 
 // Exports
 module.exports = (sources, userOptions = defaultOptions) => {
   const result = createResult();
   const options = _.merge({}, defaultOptions, userOptions);
-  const classPrefixList = _.reverse(_.sortBy(options.prefix));
+  const classPrefixList = _.reverse(_.sortBy(options.classPrefix));
   const bem = createBem(classPrefixList);
   const filePathList = globby.sync(sources);
   const blockList = _.filter(

--- a/packages/gulp-bemlinter/__tests__/index.js
+++ b/packages/gulp-bemlinter/__tests__/index.js
@@ -8,7 +8,10 @@ describe('gulp-bemlinter', () => {
       done();
     };
     
-    gulp.src('../bemlinter/__tests__/sources/*.scss')
+    gulp.src([
+        '../bemlinter/__tests__/sources/*.scss',
+        '!../bemlinter/__tests__/sources/ProjectAlright.scss'
+      ])
       .pipe(bemlinter())
       .pipe(bemlinter.format(false, spy));
   });


### PR DESCRIPTION
Fix #2 

* [x] Rename `prefix` option into `classPrefix` to prevent confusion
* [x] Documentation
* [x] Development
* [x] Tests

