### PR TITLE
Allow attribute concatenation when linting

### DIFF
--- a/__tests__/styles/class-concat.scss
+++ b/__tests__/styles/class-concat.scss
@@ -1,5 +1,5 @@
 .class-concat {
-  
+
   &{
     display: block;
     position: absolute;
@@ -37,7 +37,7 @@
       right: 30px;
     }
   }
-  
+
   &.class-concat--big {
     width: 64px;
     height: 64px;
@@ -46,5 +46,9 @@
   &#dontDoThat {
     width: 666px;
     height: 666px;
+  }
+
+  &[type="text"] {
+    border: 0;
   }
 }

--- a/src/lint.js
+++ b/src/lint.js
@@ -130,7 +130,7 @@ function bemLintFileData(filePath, data, result, blockList, options) {
         return;
       }
       const nextNodeType = next.get(0).type;
-      if (['id', 'class', 'pseudo_class', 'punctuation', 'function', 'space'].indexOf(nextNodeType) === -1) {
+      if (['id', 'class', 'attribute', 'pseudo_class', 'punctuation', 'function', 'space'].indexOf(nextNodeType) === -1) {
         const selector = nodeToString(next.parent().get(0)).trim();
         result.addError(`"${selector}" should not concatenate classes.`, filePath, moduleName, blockName, wrapper);
       }


### PR DESCRIPTION
This notation should be authorized:

```scss
.my-class {
  &[type="text"] {
    border: 0;
  }
}
```
