### PR TITLE
Prevent parsing error when a function contain an external block

### DIFF
--- a/__tests__/__snapshots__/quality.test.js.snap
+++ b/__tests__/__snapshots__/quality.test.js.snap
@@ -3,15 +3,25 @@ exports[`Bemlinter of alright.scss  should lint without errors 1`] = `
 OK: bemlinter has detected no new error."
 `;
 
-exports[`Bemlinter of leak.scss  should lint a new leak error 1`] = `
+exports[`Bemlinter of leak.scss should lint two new leak errors 1`] = `
 "  ✗ leak
 [leak.scss:10] Error: \".external-block\" is incoherent with the file name, \".leak\" expected.
+[leak.scss:14] Error: \".another-block\" is incoherent with the file name, \".leak\" expected.
 
-bemlinter has detected 1 error on 1 block.
-FAIL: bemlinter has detected 1 new error."
+bemlinter has detected 2 errors on 1 block.
+FAIL: bemlinter has detected 2 new errors."
 `;
 
-exports[`Bemlinter of leak.scss  should lint without new errors 1`] = `
-"bemlinter has detected 1 error on 1 block.
+exports[`Bemlinter of leak.scss should lint two new leak errors 2`] = `
+"  ✗ leak
+[leak.scss:10] Error: \".external-block\" is incoherent with the file name, \".leak\" expected.
+[leak.scss:14] Error: \".another-block\" is incoherent with the file name, \".leak\" expected.
+
+bemlinter has detected 2 errors on 1 block.
+FAIL: bemlinter has detected 2 new errors."
+`;
+
+exports[`Bemlinter of leak.scss should lint without new errors 1`] = `
+"bemlinter has detected 2 errors on 1 block.
 OK: bemlinter has detected no new error."
 `;

--- a/__tests__/__snapshots__/single-file.test.js.snap
+++ b/__tests__/__snapshots__/single-file.test.js.snap
@@ -13,15 +13,17 @@ FAIL: bemlinter has detected 2 errors on 1 block."
 exports[`Bemlinter of leak.css should lint with a leak error 1`] = `
 "  ✗ leak
 [leak.css:11] Error: \".external-block\" is incoherent with the file name, \".leak\" expected.
+[leak.css:15] Error: \".another-block\" is incoherent with the file name, \".leak\" expected.
 
-FAIL: bemlinter has detected 1 error on 1 block."
+FAIL: bemlinter has detected 2 errors on 1 block."
 `;
 
 exports[`Bemlinter of leak.scss should lint with a leak error 1`] = `
 "  ✗ leak
 [leak.scss:10] Error: \".external-block\" is incoherent with the file name, \".leak\" expected.
+[leak.scss:14] Error: \".another-block\" is incoherent with the file name, \".leak\" expected.
 
-FAIL: bemlinter has detected 1 error on 1 block."
+FAIL: bemlinter has detected 2 errors on 1 block."
 `;
 
 exports[`Bemlinter of mixins-content.scss should lint with a leak error 1`] = `

--- a/__tests__/quality.test.js
+++ b/__tests__/quality.test.js
@@ -10,17 +10,15 @@ const snapLintOutput = (lintResult) => {
   return output;
 };
 
-const expectNewError = errorLength => (lintResult) => {
+const expectNewError = (lintResult, errorLength) => {
   expect(lintResult.getSnapshot().getNewErrorList().length).toBe(errorLength);
 
   return lintResult;
 };
 
-const expectFileCreated = filePath => (lintResult) => {
+const expectFileCreated = filePath => {
   expect(fs.existsSync(filePath)).toBe(true);
   fs.unlinkSync(filePath);
-
-  return lintResult;
 };
 
 const getLintResult = (stylesFileName, qualityFileName, options = {}) => {
@@ -29,44 +27,96 @@ const getLintResult = (stylesFileName, qualityFileName, options = {}) => {
 };
 
 describe('Bemlinter of alright.scss ', () => {
-  it('should lint without errors', done => (
-    getLintResult('alright.scss', 'alright-snap.json')
-      .then(expectNewError(0))
-      .then(snapLintOutput)
-      .catch(console.error)
-      .then(done)
-  ));
+  let lintResult;
 
-  it('should create a quality snapshot', done => (
-    getLintResult('alright.scss', 'empty-snap.json')
-      .then(expectFileCreated(toFilePath('empty-snap.json', 'quality')))
+  beforeEach(function(done) {
+    getLintResult('alright.scss', 'alright-snap.json')
       .catch(console.error)
-      .then(done)
-  ));
+      .then(result => lintResult = result)
+      .then(done);
+  });
+
+  it('should lint without errors', () => {
+    expectNewError(lintResult, 0);
+    snapLintOutput(lintResult);
+  });
 });
 
-describe('Bemlinter of leak.scss ', () => {
-  it('should lint without new errors', done => (
+describe('Bemlinter of alright.scss ', () => {
+  let lintResult;
+
+  beforeEach(function(done) {
+    getLintResult('alright.scss', 'empty-snap.json')
+      .catch(console.error)
+      .then(result => lintResult = result)
+      .then(done);
+  });
+
+  it('should create a quality snapshot', () => {
+    expectFileCreated(toFilePath('empty-snap.json', 'quality'));
+  });
+});
+
+describe('Bemlinter of leak.scss', () => {
+  let lintResult;
+
+  beforeEach(function(done) {
     getLintResult('leak.scss', 'leak-snap.json')
-      .then(expectNewError(0))
-      .then(snapLintOutput)
       .catch(console.error)
-      .then(done)
-  ));
+      .then(result => lintResult = result)
+      .then(done);
+  });
 
-  it('should lint a new leak error', done => (
+  it('should lint without new errors', () => {
+    expectNewError(lintResult, 0);
+    snapLintOutput(lintResult);
+  });
+});
+
+describe('Bemlinter of leak.scss', () => {
+  let lintResult;
+
+  beforeEach(function(done) {
     getLintResult('leak.scss', 'alright-snap.json')
-      .then(expectNewError(1))
-      .then(snapLintOutput)
+      .then(result => lintResult = result)
       .catch(console.error)
-      .then(done)
-  ));
+      .then(done);
+  });
 
-  it('should create a quality snapshot without new errors', done => (
-    getLintResult('leak.scss', 'new-snap.json')
-      .then(expectNewError(0))
-      .then(expectFileCreated(toFilePath('new-snap.json', 'quality')))
+  it('should lint two new leak errors', () => {
+    expectNewError(lintResult, 2);
+    snapLintOutput(lintResult);
+  });
+});
+
+describe('Bemlinter of leak.scss', () => {
+  let lintResult;
+
+  beforeEach(function(done) {
+    getLintResult('leak.scss', 'alright-snap.json')
+      .then(result => lintResult = result)
       .catch(console.error)
-      .then(done)
-  ));
+      .then(done);
+  });
+
+  it('should lint two new leak errors', () => {
+    expectNewError(lintResult, 2);
+    snapLintOutput(lintResult);
+  });
+});
+
+describe('Bemlinter of leak.scss', () => {
+  let lintResult;
+
+  beforeEach(function(done) {
+    getLintResult('leak.scss', 'new-snap.json')
+      .then(result => lintResult = result)
+      .catch(console.error)
+      .then(done);
+  });
+
+  it('should create a quality snapshot without new errors', () => {
+    expectNewError(lintResult, 0);
+    expectFileCreated(toFilePath('new-snap.json', 'quality'));
+  });
 });

--- a/__tests__/quality/leak-snap.json
+++ b/__tests__/quality/leak-snap.json
@@ -4,6 +4,11 @@
       "moduleName": "__root",
       "blockName": "leak",
       "message": "\".external-block\" is incoherent with the file name, \".leak\" expected."
+    },
+    {
+      "moduleName": "__root",
+      "blockName": "leak",
+      "message": "\".another-block\" is incoherent with the file name, \".leak\" expected."
     }
   ],
   "warningList": []

--- a/__tests__/styles/leak.css
+++ b/__tests__/styles/leak.css
@@ -8,8 +8,12 @@
     height: 29px;
 }
 
-.leak .external-block {
+.leak.external-block {
     display: none;
+}
+
+.leak:not(.another-block) {
+  display: none;
 }
 
 .leak::after {

--- a/__tests__/styles/leak.scss
+++ b/__tests__/styles/leak.scss
@@ -6,8 +6,12 @@
   transform: translateY(-50%);
   width: 29px;
   height: 29px;
-  
+
   .external-block {
+    display: none;
+  }
+
+  &:not(.another-block) {
     display: none;
   }
 
@@ -31,6 +35,6 @@
   position: absolute;
   top: 14px;
   right: 15px;
-  
+
   background-image: url('/assets/close.svg');
 }

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "devDependencies": {
     "eslint": "^3.19.0",
-    "eslint-config-airbnb-base": "^11.1.3",
-    "eslint-plugin-import": "^2.2.0",
+    "eslint-config-airbnb-base": "^11.3.1",
+    "eslint-plugin-import": "^2.7.0",
     "jest": "^18.1.0"
   }
 }


### PR DESCRIPTION
Lorsque l'on détecte une block externe on va regarder l'élément suivant.
Cette recherche plante lorsque ce sélecteur est dans une fonction, par exemple `:not(.another-block) `